### PR TITLE
BAM-164: release from an input tag

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -2,6 +2,11 @@ name: Java SDK Build & Release JDK21
 
 on:
   workflow_dispatch:
+    inputs:
+      kp_tag:
+        description: 'Optional tag for kp-protocols-clientsdk'
+        required: false
+        default: ''
 
 env:
   GITHUB_ACTOR: ${{ github.actor }}
@@ -22,19 +27,23 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch head tag from kp-protocols-clientsdk
+      - name: Determine version tag from kp-protocols-clientsdk
         id: tag
         run: |
-          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
-          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [[ -z "${head_tag}" ]]; then
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+             version_tag=${{ github.event.inputs.kp_tag }}
+          else
+            git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            version_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          fi
+          if [[ -z "${version_tag}" ]]; then
             echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
             exit 1
           else
-            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
-            echo "version=${head_tag#v}" >> $GITHUB_OUTPUT
-            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+            echo "tag=${version_tag}" >> $GITHUB_OUTPUT
+            echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${version_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
           fi
 
   publish:
@@ -55,6 +64,10 @@ jobs:
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+          git checkout tags/${{ needs.tagging.outputs.tag }} -b temp-branch || { echo "Failed to checkout tag ${{ needs.tagging.outputs.tag }}"; exit 1; }
+          
+          cd ..
           mv proto-repo/src .
           rm -r proto-repo
       - name: Set up JDK 21


### PR DESCRIPTION
**Associated JIRA tasks**

BAM-161

**What does the change do?**

For a new project, we may want to release an SDK with an alpha(prerelease) version of our specification to our customers to gather early feedback. The alpha version of the specification might still be under review and reside in a task or feature branch.
Additionally, for developers, it can be beneficial to release a prerelease version of the SDK. This allows them to begin working on a specification that hasn’t been fully finalized, especially in situations requiring urgent progress.

**What has been changed**

To be able to release the such sdk from an alpha version spec, the action from the sdk repo need to checkout the protobuf spec using a manual input tag.
Also included new spec to be published for user to try

**Tests**
https://github.com/KodyPay/kody-clientsdk-java/actions/runs/12832138884 was failed due to running from task branch. It should pass once merged.
