### PR TITLE
upt: tells the compiler to generate bytecode for Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ java {
     }
 }
 
+tasks.withType<JavaCompile> {
+    options.release.set(8)
+}
 
 dependencies {
     implementation("io.grpc:grpc-protobuf:$grpcVersion")
@@ -65,7 +68,7 @@ mavenPublishing {
         description = "Kody Java gRPC Client"
         url = "https://github.com/KodyPay/kody-clientsdk-java"
         inceptionYear = "2024"
-        licenses{
+        licenses {
             license {
                 name = "MIT License"
                 url = "https://opensource.org/licenses/MIT"
@@ -82,7 +85,6 @@ mavenPublishing {
             connection = "scm:git:git://github.com/KodyPay/kody-clientsdk-java.git"
             developerConnection = "scm:git:ssh://github.com/KodyPay/kody-clientsdk-java.git"
         }
-
         signAllPublications()
         publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     }


### PR DESCRIPTION
Keep our Gradle build configuration to use a modern JDK (JDK 17 via the toolchain) for the build process and instructs the compiler to generate Java 8–compatible bytecode by setting options.release.set(8).

No change on build version:
https://github.com/KodyPay/kody-clientsdk-java/blob/main/.github/workflows/java-build.yml#L73-L77