### PR TITLE
ci: create release tag as GH_RELEASE to satisfy tag ruleset

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -111,6 +111,10 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1.14.0
         with:
+          # GH_RELEASE is a bypass-listed identity for the tag-protection
+          # ruleset; the default github-actions[bot] token is blocked
+          # ("creations being restricted") when creating the release tag.
+          token: ${{ secrets.GH_RELEASE }}
           name: "${{ needs.tagging.outputs.tag }}"
           tag: "${{ needs.tagging.outputs.tag }}"
           omitBody: true


### PR DESCRIPTION
## Summary
The Create Release step used the default github-actions[bot] token, which the tag-protection ruleset blocks ("Cannot create ref due to creations being restricted"), so publishing the release tag fails with 422. Pass secrets.GH_RELEASE (a bypass-listed org identity, as used across the other repos) to ncipollo/release-action so the tag can be created.