### PR TITLE
ci: move GH_RELEASE to checkout so gradle pushes tag directly

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -61,6 +61,8 @@ jobs:
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_RELEASE }}
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
@@ -111,10 +113,6 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1.14.0
         with:
-          # GH_RELEASE is a bypass-listed identity for the tag-protection
-          # ruleset; the default github-actions[bot] token is blocked
-          # ("creations being restricted") when creating the release tag.
-          token: ${{ secrets.GH_RELEASE }}
           name: "${{ needs.tagging.outputs.tag }}"
           tag: "${{ needs.tagging.outputs.tag }}"
           omitBody: true


### PR DESCRIPTION
## Summary
The previous fix put GH_RELEASE on the ncipollo release step, but the token resolved to empty (not yet authorized for this repo) and broke the default fallback.  Align with kody-clientsdk-kotlin: use GH_RELEASE at checkout so Nebula's `./gradlew final` pushes the tag as a bypass-listed identity; ncipollo then creates the GitHub Release on the existing tag with the default github.token.
