### PR TITLE
ci: use dedicated GH_PUB_RELEASE token for tag creation

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_RELEASE }}
+          token: ${{ secrets.GH_PUB_RELEASE }}
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo


### PR DESCRIPTION
## Summary

Public repos cannot access org-level secrets, so use a repo-level classic PAT (GH_PUB_RELEASE) for the checkout step.  Gradle's `./gradlew final` pushes the tag with this bypass-listed identity; ncipollo creates the GitHub Release on the existing tag with the default token.