### PR TITLE
fix: automatically release Maven Central deployments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ mavenPublishing {
             developerConnection = "scm:git:ssh://github.com/KodyPay/kody-clientsdk-java.git"
         }
         signAllPublications()
-        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     }
 }
 


### PR DESCRIPTION
## Summary
- `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)` defaults `automaticRelease` to `false`, so CI only *stages* a deployment in the Sonatype Central Portal — it still needs a human to log in and click **Publish** before it's visible on `repo1.maven.org`.
- That manual step hasn't happened since `1.7.30` (2025-11-26): `maven-metadata.xml` on Central still lists `1.7.30` as latest, even though `1.7.33` and `1.8.3` both have green CI runs and GitHub Releases.
- This sets `automaticRelease = true` so a successful release workflow run actually results in the version being retrievable by external consumers, with no manual portal step required.

## Follow-up needed (not in this PR)
- `1.7.33` and `1.8.3` are already stuck as pending deployments in the Central Portal and need a one-time manual publish at https://central.sonatype.com/publishing/deployments to catch up.
- Worth auditing `kody-clientsdk-kotlin`'s `build.gradle.kts` for the same `publishToMavenCentral(...)` call.

## Test plan
- [ ] `./gradlew build` succeeds locally / in CI
- [ ] Next release run publishes and the version appears in `https://repo1.maven.org/maven2/com/kodypay/grpc/kody-clientsdk-java/maven-metadata.xml` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)